### PR TITLE
Update to support most recent version of Mojolicious (7.78)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
-Revision history for CH-Something
+Revision history for MojoX::Plugin::Hook::BeforeRendered
 
 {{$NEXT}}
+
+0.31  2018-05-16
+  - update monkey patch to use 'mojo.timing' stash variable and support upgrade to Mojolicious 7.78
 
 0.30  2014-07-31
   - harmonise to CHGOVUK standard

--- a/lib/MojoX/Plugin/Hook/BeforeRendered.pm
+++ b/lib/MojoX/Plugin/Hook/BeforeRendered.pm
@@ -3,7 +3,7 @@ package MojoX::Plugin::Hook::BeforeRendered;
 use Mojo::Base 'Mojolicious::Plugin';
 use Mojo::Util qw(monkey_patch);
 
-our $VERSION = '0.30';
+our $VERSION = '0.31';
 my  $ALREADY_REGISTERED=0;
 
 # -----------------------------------------------------------------------------
@@ -28,7 +28,7 @@ sub register {
     monkey_patch "Mojolicious::Controller", rendered => sub {
         my ($self, $status) = @_;
 
-        if( $self->stash->{'mojo.started'}) {
+        if( $self->stash->{'mojo.timing'}->{'mojo.timer'}) {
             $app->hook(before_rendered => $last);
             $self->app->plugins->emit_chain(before_rendered => $self, $status );
             $self->app->plugins->unsubscribe( 'before_rendered', $last );


### PR DESCRIPTION
Note that the use of reserved `mojo.*` stash variables (a pre-existing issues with this code) means that this module is tied to the internal implementation details of a particular version of `Mojolicious` and may break when upstream changes are made. 😅 